### PR TITLE
Bump to 1.0.1, rely on script/build

### DIFF
--- a/Library/Formula/rack.rb
+++ b/Library/Formula/rack.rb
@@ -1,20 +1,21 @@
 class Rack < Formula
   desc "CLI for Rackspace"
   homepage "https://github.com/rackspace/rack"
-  url "https://github.com/rackspace/rack.git", :tag => "1.0.0",
-      :revision => "11fec2be1b7ba3f8faab745dc577e9120200d52a"
+  url "https://github.com/rackspace/rack.git", :tag => "1.0.1",
+      :revision => "71a8d7c80b3652b4dd39e683bc423b8a542b0167"
   head "https://github.com/rackspace/rack.git"
 
   depends_on "go" => :build
 
   def install
     ENV["GOPATH"] = buildpath
+    ENV["TRAVIS_TAG"] = @tag
 
     rackpath = buildpath/"src/github.com/rackspace/rack"
     rackpath.install Dir["{*,.git}"]
 
     cd rackpath do
-      system "go", "build", "-o", "rack"
+      system "script/build", "rack"
       bin.install "rack"
     end
   end


### PR DESCRIPTION
Bumping https://github.com/Homebrew/homebrew/pull/42827 to 1.0.1, relying on `script/build`, and setting the `TRAVIS_TAG`.
